### PR TITLE
Implement a tool that generates an HTML list of issues with associated PRs using the Github API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # nlstory
 A tool that converts the issues and PRs of a repository into a story
+
+## Usage
+
+To use the tool, run the following command:
+
+```
+python generate_issue_list.py <repository> <output_file>
+```
+
+### Parameters
+
+- `repository`: The name of the repository (e.g., `owner/repo`)
+- `output_file`: The name of the output file where the HTML list will be saved
+
+### Example
+
+```
+python generate_issue_list.py abrie/nlstory output.html
+```
+
+### Requirements
+
+The tool requires the `requests` library. You can install it using the following command:
+
+```
+pip install -r requirements.txt
+```
+
+### Authentication
+
+The tool uses the `GITHUB_TOKEN` environment variable for authentication. Make sure to set this variable before running the tool.
+
+```
+export GITHUB_TOKEN=<your_github_token>
+```

--- a/generate_issue_list.py
+++ b/generate_issue_list.py
@@ -1,0 +1,121 @@
+import os
+import sys
+import requests
+import json
+
+def get_issues(repository, token):
+    url = "https://api.github.com/graphql"
+    headers = {"Authorization": f"Bearer {token}"}
+    query = """
+    query($repo: String!, $cursor: String) {
+        repository(name: $repo) {
+            issues(first: 100, after: $cursor) {
+                edges {
+                    node {
+                        id
+                        title
+                        createdAt
+                        closedAt
+                        url
+                        closingIssuesReferences(first: 5) {
+                            nodes {
+                                id
+                                title
+                                url
+                            }
+                        }
+                    }
+                }
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+            }
+        }
+    }
+    """
+    issues = []
+    cursor = None
+    while True:
+        variables = {"repo": repository, "cursor": cursor}
+        response = requests.post(url, headers=headers, json={"query": query, "variables": variables})
+        data = response.json()
+        issues.extend(data["data"]["repository"]["issues"]["edges"])
+        if not data["data"]["repository"]["issues"]["pageInfo"]["hasNextPage"]:
+            break
+        cursor = data["data"]["repository"]["issues"]["pageInfo"]["endCursor"]
+    return issues
+
+def get_pull_requests(repository, token):
+    url = "https://api.github.com/graphql"
+    headers = {"Authorization": f"Bearer {token}"}
+    query = """
+    query($repo: String!, $cursor: String) {
+        repository(name: $repo) {
+            pullRequests(first: 100, after: $cursor) {
+                edges {
+                    node {
+                        id
+                        title
+                        createdAt
+                        closedAt
+                        url
+                    }
+                }
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+            }
+        }
+    }
+    """
+    pull_requests = []
+    cursor = None
+    while True:
+        variables = {"repo": repository, "cursor": cursor}
+        response = requests.post(url, headers=headers, json={"query": query, "variables": variables})
+        data = response.json()
+        pull_requests.extend(data["data"]["repository"]["pullRequests"]["edges"])
+        if not data["data"]["repository"]["pullRequests"]["pageInfo"]["hasNextPage"]:
+            break
+        cursor = data["data"]["repository"]["pullRequests"]["pageInfo"]["endCursor"]
+    return pull_requests
+
+def associate_issues_with_prs(issues, pull_requests):
+    pr_dict = {pr["node"]["id"]: pr["node"] for pr in pull_requests}
+    for issue in issues:
+        issue["node"]["associatedPRs"] = []
+        for pr in issue["node"]["closingIssuesReferences"]["nodes"]:
+            if pr["id"] in pr_dict:
+                issue["node"]["associatedPRs"].append(pr_dict[pr["id"]])
+    return issues
+
+def generate_html(issues, output_file):
+    issues.sort(key=lambda x: x["node"]["createdAt"])
+    with open(output_file, "w") as f:
+        f.write("<html><body><ul>\n")
+        for issue in issues:
+            f.write(f'<li><a href="{issue["node"]["url"]}">{issue["node"]["title"]}</a>\n')
+            if issue["node"]["associatedPRs"]:
+                f.write("<ul>\n")
+                for pr in issue["node"]["associatedPRs"]:
+                    f.write(f'<li><a href="{pr["url"]}">{pr["title"]}</a></li>\n')
+                f.write("</ul>\n")
+            f.write("</li>\n")
+        f.write("</ul></body></html>\n")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python generate_issue_list.py <repository> <output_file>")
+        sys.exit(1)
+    repository = sys.argv[1]
+    output_file = sys.argv[2]
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("Error: GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+    issues = get_issues(repository, token)
+    pull_requests = get_pull_requests(repository, token)
+    issues = associate_issues_with_prs(issues, pull_requests)
+    generate_html(issues, output_file)

--- a/generate_issue_list.py
+++ b/generate_issue_list.py
@@ -40,6 +40,9 @@ def get_issues(repository, token):
         variables = {"repo": repository, "cursor": cursor}
         response = requests.post(url, headers=headers, json={"query": query, "variables": variables})
         data = response.json()
+        if "data" not in data:
+            print("Error: 'data' key not found in the response JSON")
+            break
         issues.extend(data["data"]["repository"]["issues"]["edges"])
         if not data["data"]["repository"]["issues"]["pageInfo"]["hasNextPage"]:
             break

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Related to #1

Add a tool to generate a chronological HTML list of non-Pull Request issues and their associated Pull Requests using the Github GraphQL API.

* **generate_issue_list.py**: 
  - Add a script that accepts `repository` and `output file` as command-line parameters.
  - Use the Github GraphQL API and the GITHUB_TOKEN environment variable for authentication.
  - Fetch all non-Pull Request issues and Pull Request issues from the specified repository.
  - Associate non-Pull Request issues with referenced Pull Request issues using the `closingIssuesReferences` field.
  - Output a chronological HTML list (oldest to newest) of non-Pull Request issues and their associated Pull Requests into the specified output file.

* **requirements.txt**:
  - Add `requests` library as a dependency.

* **README.md**:
  - Add instructions on how to use the new tool, including command-line parameters and example usage.
  - Add information about the required `requests` library and how to install it.
  - Add instructions for setting the `GITHUB_TOKEN` environment variable for authentication.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/3?shareId=19ecd837-b63a-4307-9656-bd0cebfeb2fd).