### PR TITLE
Implement a tool to generate a summary list of all non-pull request issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # nlstory
 A tool that converts the issues and PRs of a repository into a story
+
+## Summary List of Non-Pull Request Issues
+This tool generates a summary list of all non-pull request issues in the repository using the python GraphQL API and jinja2 Template library.
+
+### Features
+- Fetches issues from the repository using the python GraphQL API.
+- Generates HTML output for the summary list using the jinja2 Template library.
+- Only lists issues that are not pull requests by filtering nodes based on the `__typename` field in the GraphQL response.
+
+### Usage
+1. Set the `GITHUB_TOKEN` environment variable for authentication.
+2. Run the tool to generate the summary list of non-pull request issues.

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -1,0 +1,50 @@
+import os
+import requests
+import jinja2
+
+def fetch_issues():
+    url = "https://api.github.com/graphql"
+    query = """
+    {
+      repository(owner: "abrie", name: "nl12") {
+        issues(first: 100) {
+          nodes {
+            __typename
+            title
+            body
+            url
+          }
+        }
+      }
+    }
+    """
+    headers = {"Authorization": f"Bearer {os.getenv('GITHUB_TOKEN')}"}
+    response = requests.post(url, json={'query': query}, headers=headers)
+    if response.status_code != 200:
+        raise Exception(f"Query failed to run by returning code of {response.status_code}. {query}")
+    return [issue for issue in response.json()['data']['repository']['issues']['nodes'] if issue['__typename'] == 'Issue']
+
+def generate_html(issues):
+    template = jinja2.Template("""
+    <html>
+    <head><title>Summary of Issues</title></head>
+    <body>
+    <h1>Summary of Issues</h1>
+    <ul>
+    {% for issue in issues %}
+      <li><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}</li>
+    {% endfor %}
+    </ul>
+    </body>
+    </html>
+    """)
+    return template.render(issues=issues)
+
+def main():
+    issues = fetch_issues()
+    html_output = generate_html(issues)
+    with open("summary.html", "w") as f:
+        f.write(html_output)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Related to #5

Add functionality to generate a summary list of non-pull request issues in the repository.

* **README.md**
  - Add a section describing the new functionality to generate a summary list of non-pull request issues.
  - Mention the use of the python GraphQL API and jinja2 Template library.
  - Provide usage instructions for setting the `GITHUB_TOKEN` environment variable and running the tool.

* **generate_summary.py**
  - Import necessary libraries: `os`, `requests`, `jinja2`.
  - Define a function `fetch_issues` to fetch issues from the repository using the GraphQL API.
  - Define a function `generate_html` to generate HTML output using jinja2 Template library.
  - Define a function `main` to coordinate fetching issues and generating HTML output.
  - Use the `GITHUB_TOKEN` environment variable for authentication.
  - Filter nodes based on the `__typename` field to exclude pull requests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/6?shareId=f69724a6-798a-4821-b702-c4121e2a0dc9).