### PR TITLE
Add PR request summaries to each Issue in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # nlstory
 A tool that converts the issues and PRs of a repository into a story
 
-## Summary List of Non-Pull Request Issues
-This tool generates a summary list of all non-pull request issues in the repository using the python GraphQL API and jinja2 Template library.
+## Summary List of Issues with Associated Pull Requests
+This tool generates a summary list of all issues in the repository, including associated pull requests, using the python GraphQL API and jinja2 Template library.
 
 ### Features
 - Fetches issues from the repository using the python GraphQL API.
 - Generates HTML output for the summary list using the jinja2 Template library.
-- Only lists issues that are not pull requests by filtering nodes based on the `__typename` field in the GraphQL response.
+- Lists associated pull requests underneath each issue by querying the `closingIssuesReferences` field in the GraphQL response.
+- Highlights merged pull requests in the summary output by adding a CSS class.
 
 ### Usage
 1. Set the `GITHUB_TOKEN` environment variable for authentication.
-2. Run the tool to generate the summary list of non-pull request issues.
+2. Run the tool to generate the summary list of issues with associated pull requests.


### PR DESCRIPTION
Related to #7

Add associated Pull Requests to issue summary output and highlight merged pull requests.

* Update `generate_summary.py` to include `closingIssuesReferences` field in the GraphQL query.
* Add `fetch_pull_requests` function to query for associated Pull Requests.
* Update HTML template in `generate_summary.py` to list associated Pull Requests underneath each issue and highlight merged pull requests with a CSS class.
* Update `README.md` to describe the tool as generating a summary list of issues with associated Pull Requests listed underneath each issue and highlighting merged pull requests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/8?shareId=b2ec752f-ad64-4f2e-b51a-a9f66051f5f4).