### PR TITLE
Add PR request summaries to each Issue in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # nlstory
 A tool that converts the issues and PRs of a repository into a story
 
-## Summary List of Non-Pull Request Issues
-This tool generates a summary list of all non-pull request issues in the repository using the python GraphQL API and jinja2 Template library.
+## Summary List of Issues with Associated Pull Requests
+This tool generates a summary list of all issues in the repository, including associated Pull Requests listed underneath each issue, using the python GraphQL API and jinja2 Template library.
 
 ### Features
 - Fetches issues from the repository using the python GraphQL API.
 - Generates HTML output for the summary list using the jinja2 Template library.
+- Lists associated Pull Requests underneath each issue by querying the `linkedPullRequests` field in the GraphQL response.
+- Highlights merged pull requests in the summary output.
 - Only lists issues that are not pull requests by filtering nodes based on the `__typename` field in the GraphQL response.
 
 ### Usage
 1. Set the `GITHUB_TOKEN` environment variable for authentication.
-2. Run the tool to generate the summary list of non-pull request issues.
+2. Run the tool to generate the summary list of issues with associated Pull Requests.

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -13,7 +13,7 @@ def fetch_issues():
             title
             body
             url
-            linkedPullRequests(first: 10) {
+            closingIssuesReferences(first: 10) {
               nodes {
                 title
                 url
@@ -40,9 +40,9 @@ def generate_html(issues):
     <ul>
     {% for issue in issues %}
       <li><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}
-        {% if issue.linkedPullRequests.nodes|length > 0 %}
+        {% if issue.closingIssuesReferences.nodes|length > 0 %}
         <ul>
-          {% for pr in issue.linkedPullRequests.nodes %}
+          {% for pr in issue.closingIssuesReferences.nodes %}
           <li><a href="{{ pr.url }}">{{ pr.title }}</a>{% if pr.merged %} (Merged){% endif %}</li>
           {% endfor %}
         </ul>

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -13,6 +13,13 @@ def fetch_issues():
             title
             body
             url
+            linkedPullRequests(first: 10) {
+              nodes {
+                title
+                url
+                merged
+              }
+            }
           }
         }
       }
@@ -32,7 +39,15 @@ def generate_html(issues):
     <h1>Summary of Issues</h1>
     <ul>
     {% for issue in issues %}
-      <li><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}</li>
+      <li><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}
+        {% if issue.linkedPullRequests.nodes|length > 0 %}
+        <ul>
+          {% for pr in issue.linkedPullRequests.nodes %}
+          <li><a href="{{ pr.url }}">{{ pr.title }}</a>{% if pr.merged %} (Merged){% endif %}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </li>
     {% endfor %}
     </ul>
     </body>


### PR DESCRIPTION
Related to #7

Add listing of associated Pull Requests underneath each issue in the summary output.

* Update `generate_summary.py` to include the `linkedPullRequests` field in the GraphQL query and process it in the issue data.
* Modify the HTML template in `generate_summary.py` to list associated Pull Requests underneath each issue, with merged pull requests highlighted.
* Update `README.md` to describe the tool as generating a summary list of issues with associated Pull Requests listed underneath each issue and highlighting merged pull requests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/9?shareId=3b546062-85a1-4cfd-a67f-f5024cd1f89f).