### PR TITLE
Add a list of associated PR requests to each Issue in the summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This tool generates a summary list of all non-pull request issues in the reposit
 - Fetches issues from the repository using the python GraphQL API.
 - Generates HTML output for the summary list using the jinja2 Template library.
 - Only lists issues that are not pull requests by filtering nodes based on the `__typename` field in the GraphQL response.
+- Includes associated pull requests for each issue by fetching `timelineItems` and filtering for `CrossReferencedEvent`.
 
 ### Usage
 1. Set the `GITHUB_TOKEN` environment variable for authentication.
-2. Run the tool to generate the summary list of non-pull request issues.
+2. Run the tool to generate the summary list of non-pull request issues and their associated pull requests.


### PR DESCRIPTION
Related to #7

Add a list of associated PR requests to each Issue in the summary output.

* **generate_summary.py**
  - Update the GraphQL query to include `timelineItems` connection and filter for `CrossReferencedEvent` to find linked pull requests.
  - Update the `fetch_issues` function to process the additional data and include the associated PRs in the issue data.
  - Update the HTML template to display associated PRs under each issue.

* **README.md**
  - Update the features section to mention the inclusion of associated pull requests.
  - Update the usage section to reflect the changes in the tool.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/10?shareId=0053b801-4488-4798-9ac0-2e4c03ec3e7a).