### PR TITLE
Add events to issues in summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This tool generates a summary list of all non-pull request issues in the reposit
 - Fetches issues from the repository using the python GraphQL API.
 - Generates HTML output for the summary list using the jinja2 Template library.
 - Only lists issues that are not pull requests by filtering nodes based on the `__typename` field in the GraphQL response.
+- Lists associated events for each non-PR issue chronologically (earliest to latest).
 
 ### Usage
 1. Set the `GITHUB_TOKEN` environment variable for authentication.
-2. Run the tool to generate the summary list of non-pull request issues.
+2. Run the tool to generate the summary list of non-pull request issues along with their associated events.

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -13,6 +13,49 @@ def fetch_issues():
             title
             body
             url
+            timelineItems(first: 100) {
+              nodes {
+                __typename
+                ... on LabeledEvent {
+                  createdAt
+                  label {
+                    name
+                  }
+                }
+                ... on UnlabeledEvent {
+                  createdAt
+                  label {
+                    name
+                  }
+                }
+                ... on MilestonedEvent {
+                  createdAt
+                  milestoneTitle
+                }
+                ... on DemilestonedEvent {
+                  createdAt
+                  milestoneTitle
+                }
+                ... on ClosedEvent {
+                  createdAt
+                }
+                ... on ReopenedEvent {
+                  createdAt
+                }
+                ... on AssignedEvent {
+                  createdAt
+                  assignee {
+                    login
+                  }
+                }
+                ... on UnassignedEvent {
+                  createdAt
+                  assignee {
+                    login
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -32,7 +75,32 @@ def generate_html(issues):
     <h1>Summary of Issues</h1>
     <ul>
     {% for issue in issues %}
-      <li><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}</li>
+      <li>
+        <a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}
+        <ul>
+        {% for event in issue.timelineItems.nodes %}
+          <li>{{ event.createdAt }} - 
+            {% if event.__typename == 'LabeledEvent' %}
+              Labeled: {{ event.label.name }}
+            {% elif event.__typename == 'UnlabeledEvent' %}
+              Unlabeled: {{ event.label.name }}
+            {% elif event.__typename == 'MilestonedEvent' %}
+              Milestoned: {{ event.milestoneTitle }}
+            {% elif event.__typename == 'DemilestonedEvent' %}
+              Demilestoned: {{ event.milestoneTitle }}
+            {% elif event.__typename == 'ClosedEvent' %}
+              Closed
+            {% elif event.__typename == 'ReopenedEvent' %}
+              Reopened
+            {% elif event.__typename == 'AssignedEvent' %}
+              Assigned to: {{ event.assignee.login }}
+            {% elif event.__typename == 'UnassignedEvent' %}
+              Unassigned from: {{ event.assignee.login }}
+            {% endif %}
+          </li>
+        {% endfor %}
+        </ul>
+      </li>
     {% endfor %}
     </ul>
     </body>
@@ -42,6 +110,8 @@ def generate_html(issues):
 
 def main():
     issues = fetch_issues()
+    for issue in issues:
+        issue['timelineItems']['nodes'].sort(key=lambda x: x['createdAt'])
     html_output = generate_html(issues)
     with open("summary.html", "w") as f:
         f.write(html_output)


### PR DESCRIPTION
Related to #11

Add functionality to list associated events for each non-PR issue chronologically.

* **generate_summary.py**
  - Add a new GraphQL query to fetch events for each issue.
  - Modify `fetch_issues` to include events in the response.
  - Modify `generate_html` to include events in the HTML output.
  - Sort and display events chronologically for each issue.

* **README.md**
  - Update to reflect the new feature of listing associated events for each non-PR issue.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/12?shareId=1ca2248f-5522-4821-b08e-5c39f9c88efe).