### PR TITLE
Add a list of associated PR requests to each issue in the summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This tool generates a summary list of all non-pull request issues in the reposit
 - Fetches issues from the repository using the python GraphQL API.
 - Generates HTML output for the summary list using the jinja2 Template library.
 - Only lists issues that are not pull requests by filtering nodes based on the `__typename` field in the GraphQL response.
+- Lists associated PR requests for each issue using `timelineItems` with `CrossReferencesEvent` and `PullRequest`.
 
 ### Usage
 1. Set the `GITHUB_TOKEN` environment variable for authentication.

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -13,6 +13,18 @@ def fetch_issues():
             title
             body
             url
+            timelineItems(first: 100) {
+              nodes {
+                ... on CrossReferencedEvent {
+                  source {
+                    ... on PullRequest {
+                      number
+                      title
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -32,7 +44,17 @@ def generate_html(issues):
     <h1>Summary of Issues</h1>
     <ul>
     {% for issue in issues %}
-      <li><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}</li>
+      <li><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}
+        {% if issue.timelineItems.nodes|length > 0 %}
+          <ul>
+          {% for event in issue.timelineItems.nodes %}
+            {% if event.source.__typename == 'PullRequest' %}
+              <li>PR #{{ event.source.number }}: {{ event.source.title }}</li>
+            {% endif %}
+          {% endfor %}
+          </ul>
+        {% endif %}
+      </li>
     {% endfor %}
     </ul>
     </body>


### PR DESCRIPTION
Related to #7

Add a list of associated PR requests to each issue in the summary output.

* **GraphQL Query Update**
  - Update the GraphQL query in `generate_summary.py` to fetch `timelineItems` with `CrossReferencesEvent` and `PullRequest` for each issue.

* **HTML Template Update**
  - Update the `generate_html` function in `generate_summary.py` to include a section for listing associated PR requests for each issue.

* **Documentation Update**
  - Update `README.md` to mention the new feature of listing associated PR requests for each issue.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/13?shareId=d4983d28-a639-4afd-9fb7-27a7f215fff1).