### PR TITLE
Update summary to include both PR issues and non-PR issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # nlstory
 A tool that converts the issues and PRs of a repository into a story
 
-## Summary List of Non-Pull Request Issues
-This tool generates a summary list of all non-pull request issues in the repository using the python GraphQL API and jinja2 Template library.
+## Summary List of Issues and Pull Requests
+This tool generates a summary list of all issues and pull requests in the repository using the python GraphQL API and jinja2 Template library.
 
 ### Features
-- Fetches issues from the repository using the python GraphQL API.
+- Fetches issues and pull requests from the repository using the python GraphQL API.
 - Generates HTML output for the summary list using the jinja2 Template library.
-- Only lists issues that are not pull requests by filtering nodes based on the `__typename` field in the GraphQL response.
 
 ### Usage
 1. Set the `GITHUB_TOKEN` environment variable for authentication.
-2. Run the tool to generate the summary list of non-pull request issues.
+2. Run the tool to generate the summary list of issues and pull requests.

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -9,7 +9,13 @@ def fetch_issues():
       repository(owner: "abrie", name: "nl12") {
         issues(first: 100) {
           nodes {
-            __typename
+            title
+            body
+            url
+          }
+        }
+        pullRequests(first: 100) {
+          nodes {
             title
             body
             url
@@ -22,7 +28,9 @@ def fetch_issues():
     response = requests.post(url, json={'query': query}, headers=headers)
     if response.status_code != 200:
         raise Exception(f"Query failed to run by returning code of {response.status_code}. {query}")
-    return [issue for issue in response.json()['data']['repository']['issues']['nodes'] if issue['__typename'] == 'Issue']
+    issues = response.json()['data']['repository']['issues']['nodes']
+    pull_requests = response.json()['data']['repository']['pullRequests']['nodes']
+    return issues + pull_requests
 
 def generate_html(issues):
     template = jinja2.Template("""


### PR DESCRIPTION
Related to #16

Update the summary to include both PR issues and non-PR issues.

* Modify `generate_summary.py` to fetch both issues and pull requests by updating the GraphQL query and removing the filtering condition based on the `__typename` field.
* Update `README.md` to specify that the tool generates a summary list of both issues and pull requests and update the usage instructions accordingly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/17?shareId=8a713a50-de91-47b9-ad5f-e50c8a722e0d).