### PR TITLE
Show merged PR requests in green

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This tool generates a summary list of all issues and pull requests in the reposi
 ### Features
 - Fetches issues and pull requests from the repository using the python GraphQL API.
 - Generates HTML output for the summary list using the jinja2 Template library.
+- Shows merged pull requests in green.
 
 ### Usage
 1. Set the `GITHUB_TOKEN` environment variable for authentication.

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -19,6 +19,7 @@ def fetch_issues():
             title
             body
             url
+            merged
           }
         }
       }
@@ -35,12 +36,19 @@ def fetch_issues():
 def generate_html(issues):
     template = jinja2.Template("""
     <html>
-    <head><title>Summary of Issues</title></head>
+    <head>
+      <title>Summary of Issues</title>
+      <style>
+        .merged {
+          color: green;
+        }
+      </style>
+    </head>
     <body>
     <h1>Summary of Issues</h1>
     <ul>
     {% for issue in issues %}
-      <li><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}</li>
+      <li class="{{ 'merged' if issue.merged else '' }}"><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}</li>
     {% endfor %}
     </ul>
     </body>


### PR DESCRIPTION
Related to #18

Add feature to show merged pull requests in green.

* Fetch the `merged` status of pull requests in `generate_summary.py`.
* Add a CSS style to display merged pull requests in green in `generate_summary.py`.
* Update `README.md` to mention the feature of showing merged PRs in green.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/19?shareId=984e83f8-bf29-4055-93b0-2e4d1c0d2a8a).