### PR TITLE
Update summary display to show only issue number and title

### DIFF
--- a/generate_summary.py
+++ b/generate_summary.py
@@ -10,15 +10,13 @@ def fetch_issues():
         issues(first: 100) {
           nodes {
             title
-            body
-            url
+            number
           }
         }
         pullRequests(first: 100) {
           nodes {
             title
-            body
-            url
+            number
           }
         }
       }

--- a/index.html.jinja
+++ b/index.html.jinja
@@ -11,7 +11,7 @@
       <h1>Summary of Issues</h1>
       <ul>
         {% for issue in issues %}
-          <li><a href="{{ issue.url }}">{{ issue.title }}</a>: {{ issue.body }}</li>
+          <li>{{ issue.number }}: {{ issue.title }}</li>
         {% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
Related to #22

Update `generate_summary.py` and `index.html.jinja` to only show issue number and title.

* **generate_summary.py**
  - Update `fetch_issues` function to retrieve title and number for each issue and pull request
  - Modify `generate_html` function to render issues and pull requests with titles and numbers only

* **index.html.jinja**
  - Update template to display only the issue number and title without links or summaries

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/23?shareId=54993998-cfeb-4bab-9a89-6d4d80f0d46d).