### PR TITLE
Sort issues and PRs chronologically

### DIFF
--- a/generate_summary.py
+++ b/generate_summary.py
@@ -11,12 +11,14 @@ def fetch_issues():
           nodes {
             title
             number
+            createdAt
           }
         }
         pullRequests(first: 100) {
           nodes {
             title
             number
+            createdAt
           }
         }
       }
@@ -32,7 +34,9 @@ def fetch_issues():
         issue['is_pr'] = False
     for pr in pull_requests:
         pr['is_pr'] = True
-    return issues + pull_requests
+    combined_list = issues + pull_requests
+    combined_list.sort(key=lambda x: x['createdAt'])
+    return combined_list
 
 def generate_html(issues):
     template_loader = jinja2.FileSystemLoader(searchpath="./")

--- a/index.html.jinja
+++ b/index.html.jinja
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + TS</title>
+    <title>Summary of Issues and Pull Requests</title>
   </head>
   <body>
     <div id="app">
-      <h1>Summary of Issues</h1>
+      <h1>Summary of Issues and Pull Requests</h1>
       <ul>
         {% for issue in issues %}
           <li>{% if issue.is_pr %}PR {% endif %}{{ issue.number }}: {{ issue.title }}</li>


### PR DESCRIPTION
Related to #26

Sort issues and pull requests chronologically by creation date.

* Add `createdAt` field to the GraphQL query in `generate_summary.py` to fetch creation dates for issues and pull requests.
* Sort the combined list of issues and pull requests by `createdAt` in ascending order in `generate_summary.py`.
* Update the title in `index.html.jinja` to "Summary of Issues and Pull Requests".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/27?shareId=9cd60f9e-328d-4940-938b-a909c89332cb).