### PR TITLE
Label PRs as either merged or not merged

### DIFF
--- a/generate_summary.py
+++ b/generate_summary.py
@@ -19,6 +19,7 @@ def fetch_issues():
             title
             number
             createdAt
+            merged
           }
         }
       }
@@ -34,6 +35,7 @@ def fetch_issues():
         issue['is_pr'] = False
     for pr in pull_requests:
         pr['is_pr'] = True
+        pr['merged'] = pr.get('merged', False)
     combined_list = issues + pull_requests
     combined_list.sort(key=lambda x: x['createdAt'])
     return combined_list

--- a/index.html.jinja
+++ b/index.html.jinja
@@ -11,7 +11,18 @@
       <h1>Summary of Issues and Pull Requests</h1>
       <ul>
         {% for issue in issues %}
-          <li>{% if issue.is_pr %}PR {% endif %}{{ issue.number }}: {{ issue.title }}</li>
+          <li>
+            {% if issue.is_pr %}
+              PR {{ issue.number }}: {{ issue.title }}
+              {% if issue.merged %}
+                <span style="color: green;">(Merged)</span>
+              {% else %}
+                <span style="color: red;">(Not Merged)</span>
+              {% endif %}
+            {% else %}
+              Issue {{ issue.number }}: {{ issue.title }}
+            {% endif %}
+          </li>
         {% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
Related to #28

Add merged status indicator for pull requests.

* Update the GraphQL query in `generate_summary.py` to fetch the merged status of PRs.
* Add a new field `merged` to the pull request data in `generate_summary.py`.
* Update the `fetch_issues` function in `generate_summary.py` to include the merged status.
* Modify the `index.html.jinja` template to display the merged status for pull requests with appropriate styling for merged and not merged PRs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/29?shareId=dc3a0879-de7c-4826-9190-d7257a3b9caf).