### PR TITLE
Display PR issues as sub lists under referenced issue

### DIFF
--- a/index.html.jinja
+++ b/index.html.jinja
@@ -28,6 +28,27 @@
               </ul>
             {% else %}
               Issue {{ issue.number }}: {{ issue.title }}
+              {% if issue.pull_requests %}
+                <ul>
+                  {% for pr in issue.pull_requests %}
+                    <li>
+                      PR {{ pr.number }}: {{ pr.title }}
+                      {% if pr.merged %}
+                        <span style="color: green;">(Merged)</span>
+                      {% else %}
+                        <span style="color: red;">(Not Merged)</span>
+                      {% endif %}
+                      <ul>
+                        {% for commit in pr.commits %}
+                          <li>
+                            <strong>Message:</strong> {{ commit.message }}
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
             {% endif %}
           </li>
         {% endfor %}


### PR DESCRIPTION
Related to #34

Add functionality to display pull request issues as sub lists under referenced issues.

* **generate_summary.py**
  - Add `parse_commit_message_for_issue_references` function to parse commit messages for issue references.
  - Modify `fetch_issues` to associate pull requests with referenced issues.
  - Update the combined list to include pull requests under their referenced issues.

* **index.html.jinja**
  - Modify the template to display pull requests as sub lists under referenced issues.
  - Add a check to display issues without associated pull requests as before.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/35?shareId=d052b9f9-c492-4e8d-b34e-124b3e89686c).