### PR TITLE
Display the PR commit messages as HTML instead of markdown

### DIFF
--- a/generate_summary.py
+++ b/generate_summary.py
@@ -2,6 +2,7 @@ import os
 import requests
 import jinja2
 import re
+import markdown2  # P4528
 
 def parse_commit_message_for_issue_references(commit_message):
     issue_references = re.findall(r'#(\d+)', commit_message)
@@ -49,7 +50,7 @@ def fetch_issues():
     for pr in pull_requests:
         pr['is_pr'] = True
         pr['merged'] = pr.get('merged', False)
-        pr['commits'] = [{'message': commit['commit']['message']} for commit in pr['commits']['nodes']]
+        pr['commits'] = [{'message': markdown2.markdown(commit['commit']['message'])} for commit in pr['commits']['nodes']]  # P8dc9
         for commit in pr['commits']:
             referenced_issues = parse_commit_message_for_issue_references(commit['message'])
             for issue_number in referenced_issues:

--- a/index.html.jinja
+++ b/index.html.jinja
@@ -22,7 +22,7 @@
               <ul>
                 {% for commit in issue.commits %}
                   <li>
-                    <strong>Message:</strong> {{ commit.message }}
+                    <strong>Message:</strong> {{ commit.message | safe }}
                   </li>
                 {% endfor %}
               </ul>
@@ -41,7 +41,7 @@
                       <ul>
                         {% for commit in pr.commits %}
                           <li>
-                            <strong>Message:</strong> {{ commit.message }}
+                            <strong>Message:</strong> {{ commit.message | safe }}
                           </li>
                         {% endfor %}
                       </ul>


### PR DESCRIPTION
Related to #36

Convert PR commit messages from markdown to HTML and display them in the template.

* **generate_summary.py**
  - Import the `markdown2` library to convert markdown to HTML.
  - Convert commit messages from markdown to HTML in the `fetch_issues` function.

* **index.html.jinja**
  - Update the template to render commit messages as HTML using the `| safe` filter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/37?shareId=9dd02950-d39a-4880-b35d-bf891edc242b).