### PR TITLE
Include the commit hash for each PR merged into the trunk

### DIFF
--- a/generate_summary.py
+++ b/generate_summary.py
@@ -30,7 +30,7 @@ def fetch_issues():
               nodes {
                 commit {
                   message
-                  hash
+                  oid
                 }
               }
             }
@@ -51,7 +51,7 @@ def fetch_issues():
     for pr in pull_requests:
         pr['is_pr'] = True
         pr['merged'] = pr.get('merged', False)
-        pr['commits'] = [{'message': markdown2.markdown(commit['commit']['message']), 'hash': commit['commit']['hash']} for commit in pr['commits']['nodes']]  # P8dc9
+        pr['commits'] = [{'message': markdown2.markdown(commit['commit']['message']), 'hash': commit['commit']['oid']} for commit in pr['commits']['nodes']]  # P8dc9
         for commit in pr['commits']:
             referenced_issues = parse_commit_message_for_issue_references(commit['message'])
             for issue_number in referenced_issues:

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -30,6 +30,7 @@ def fetch_issues():
               nodes {
                 commit {
                   message
+                  hash
                 }
               }
             }
@@ -50,7 +51,7 @@ def fetch_issues():
     for pr in pull_requests:
         pr['is_pr'] = True
         pr['merged'] = pr.get('merged', False)
-        pr['commits'] = [{'message': markdown2.markdown(commit['commit']['message'])} for commit in pr['commits']['nodes']]  # P8dc9
+        pr['commits'] = [{'message': markdown2.markdown(commit['commit']['message']), 'hash': commit['commit']['hash']} for commit in pr['commits']['nodes']]  # P8dc9
         for commit in pr['commits']:
             referenced_issues = parse_commit_message_for_issue_references(commit['message'])
             for issue_number in referenced_issues:

--- a/index.html.jinja
+++ b/index.html.jinja
@@ -23,6 +23,8 @@
                 {% for commit in issue.commits %}
                   <li>
                     <strong>Message:</strong> {{ commit.message | safe }}
+                    <br>
+                    <strong>Hash:</strong> {{ commit.hash }}
                   </li>
                 {% endfor %}
               </ul>
@@ -42,6 +44,8 @@
                         {% for commit in pr.commits %}
                           <li>
                             <strong>Message:</strong> {{ commit.message | safe }}
+                            <br>
+                            <strong>Hash:</strong> {{ commit.hash }}
                           </li>
                         {% endfor %}
                       </ul>


### PR DESCRIPTION
Related to #38

Add commit hash display for each PR merged into the trunk.

* Modify `generate_summary.py` to include the `hash` field in the GraphQL query and update the `commits` list comprehension to include the `hash` field.
* Update `generate_html` function in `generate_summary.py` to pass the `hash` field to the template.
* Modify `index.html.jinja` to display the commit hash along with the commit message in the `commits` loop.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/39?shareId=117e5352-a700-40b7-9527-704f60dea2f4).