### PR TITLE
Place the green 'merged' text in the summary section of a PR request

### DIFF
--- a/index.html.jinja
+++ b/index.html.jinja
@@ -14,12 +14,14 @@
           <li>
             {% if issue.is_pr %}
               <details>
-                <summary>PR {{ issue.number }}: {{ issue.title }}</summary>
-                {% if issue.merged %}
-                  <span style="color: green;">(Merged)</span>
-                {% else %}
-                  <span style="color: red;">(Not Merged)</span>
-                {% endif %}
+                <summary>
+                  PR {{ issue.number }}: {{ issue.title }}
+                  {% if issue.merged %}
+                    <span style="color: green;">(Merged)</span>
+                  {% else %}
+                    <span style="color: red;">(Not Merged)</span>
+                  {% endif %}
+                </summary>
                 <ul>
                   {% for commit in issue.commits %}
                     <li>
@@ -37,12 +39,14 @@
                   {% for pr in issue.pull_requests %}
                     <li>
                       <details>
-                        <summary>PR {{ pr.number }}: {{ pr.title }}</summary>
-                        {% if pr.merged %}
-                          <span style="color: green;">(Merged)</span>
-                        {% else %}
-                          <span style="color: red;">(Not Merged)</span>
-                        {% endif %}
+                        <summary>
+                          PR {{ pr.number }}: {{ pr.title }}
+                          {% if pr.merged %}
+                            <span style="color: green;">(Merged)</span>
+                          {% else %}
+                            <span style="color: red;">(Not Merged)</span>
+                          {% endif %}
+                        </summary>
                         <ul>
                           {% for commit in pr.commits %}
                             <li>


### PR DESCRIPTION
Related to #42

Move the merged status text to the summary section of a PR request in `index.html.jinja`.

* Update the summary section to include the merged status text for issues.
* Update the summary section to include the merged status text for pull requests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/43?shareId=69145497-046a-417a-840e-cb0cbaa02456).