### PR TITLE
Show main trunk commits that are not from PR requests

### DIFF
--- a/index.html.jinja
+++ b/index.html.jinja
@@ -33,8 +33,8 @@
                 </ul>
               </details>
             {% else %}
-              Issue {{ issue.number }}: {{ issue.title }}
               {% if issue.pull_requests %}
+                Issue {{ issue.number }}: {{ issue.title }}
                 <ul>
                   {% for pr in issue.pull_requests %}
                     <li>
@@ -60,6 +60,8 @@
                     </li>
                   {% endfor %}
                 </ul>
+              {% else %}
+                Commit {{ issue.number }}: {{ issue.title }}
               {% endif %}
             {% endif %}
           </li>


### PR DESCRIPTION
Related to #44

Include main trunk commits that are not from PR requests in the list of Issues and ensure they fit in the chronology.

* Modify `generate_summary.py` to fetch main trunk commits and integrate them into the combined list of issues and pull requests.
* Sort the combined list by `createdAt`.
* Update `index.html.jinja` to display main trunk commits in the list of Issues and ensure they fit in the chronology.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/45?shareId=23de6e50-1f79-4016-b80b-a3e6b271c02e).