### PR TITLE
Add commit summary tool

### DIFF
--- a/commit-pr-issue-tool/generate_summary.py
+++ b/commit-pr-issue-tool/generate_summary.py
@@ -31,7 +31,9 @@ def fetch_commits():
     if response.status_code != 200:
         raise Exception(f"Query failed to run by returning code of {response.status_code}. {query}")
     commits = response.json()['data']['repository']['defaultBranchRef']['target']['history']['edges']
-    return [{'message': markdown2.markdown(commit['node']['message']), 'sha': commit['node']['oid'], 'date': commit['node']['committedDate']} for commit in commits]
+    commits_list = [{'message': markdown2.markdown(commit['node']['message']), 'sha': commit['node']['oid'], 'date': commit['node']['committedDate']} for commit in commits]
+    commits_list.sort(key=lambda x: x['date'])
+    return commits_list
 
 def generate_html(commits):
     template_loader = jinja2.FileSystemLoader(searchpath="./commit-pr-issue-tool")

--- a/commit-pr-issue-tool/generate_summary.py
+++ b/commit-pr-issue-tool/generate_summary.py
@@ -1,0 +1,49 @@
+import os
+import requests
+import jinja2
+import markdown2
+
+def fetch_commits():
+    url = "https://api.github.com/graphql"
+    query = """
+    {
+      repository(owner: "abrie", name: "nl12") {
+        defaultBranchRef {
+          target {
+            ... on Commit {
+              history(first: 100) {
+                edges {
+                  node {
+                    message
+                    oid
+                    committedDate
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    headers = {"Authorization": f"Bearer {os.getenv('GITHUB_TOKEN')}"}
+    response = requests.post(url, json={'query': query}, headers=headers)
+    if response.status_code != 200:
+        raise Exception(f"Query failed to run by returning code of {response.status_code}. {query}")
+    commits = response.json()['data']['repository']['defaultBranchRef']['target']['history']['edges']
+    return [{'message': markdown2.markdown(commit['node']['message']), 'sha': commit['node']['oid'], 'date': commit['node']['committedDate']} for commit in commits]
+
+def generate_html(commits):
+    template_loader = jinja2.FileSystemLoader(searchpath="./commit-pr-issue-tool")
+    template_env = jinja2.Environment(loader=template_loader)
+    template = template_env.get_template("index.html.jinja")
+    return template.render(commits=commits)
+
+def main():
+    commits = fetch_commits()
+    html_output = generate_html(commits)
+    with open("commit-pr-issue-tool/index.html", "w") as f:
+        f.write(html_output)
+
+if __name__ == "__main__":
+    main()

--- a/commit-pr-issue-tool/index.html.jinja
+++ b/commit-pr-issue-tool/index.html.jinja
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Summary of Commits</title>
+  </head>
+  <body>
+    <div id="app">
+      <h1>Summary of Commits</h1>
+      <ul>
+        {% for commit in commits %}
+          <li>
+            <strong>Message:</strong> {{ commit.commit.message | safe }}
+            <br>
+            <strong>Hash:</strong> {{ commit.sha }}
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>


### PR DESCRIPTION
Related to #46

Add a new summary tool in the `commit-pr-issue-tool` folder.

* **commit-pr-issue-tool/generate_summary.py**
  - Import `os`, `requests`, `jinja2`, and `markdown2` libraries.
  - Define `fetch_commits` function to fetch commits from the `abrie/nl12` repository using the GraphQL API.
  - Define `generate_html` function to generate HTML output using a jinja template.
  - Define `main` function to fetch commits and generate HTML output.
  - Write HTML output to `commit-pr-issue-tool/index.html`.

* **commit-pr-issue-tool/index.html.jinja**
  - Create a jinja template for the new summary tool.
  - Include a title "Summary of Commits".
  - Use a loop to list all commits chronologically.
  - Display commit message and hash for each commit.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nlstory/pull/47?shareId=876a3b02-4603-4e39-9dea-2486447f4d9b).